### PR TITLE
Add Dependabot config and CodeQL workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for weekly npm + github-actions updates (dev/prod grouped)
- Add `.github/workflows/codeql.yml` running `security-extended` on push, PR, and weekly cron
- Pairs with repo-side toggles already enabled via API: Dependabot alerts, Dependabot security updates, private vulnerability reporting, secret scanning + push protection

## Test plan
- [ ] Dependabot tab shows the config as valid after merge
- [ ] CodeQL workflow runs successfully on this PR
- [ ] No new alerts flagged on the current codebase (scaffolding only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)