### PR TITLE
Pin CodeQL workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,13 +23,13 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Repo has `sha_pinning_required: true` on Actions, so tag refs like `@v6` will fail workflow validation
- Pin `actions/checkout` and `github/codeql-action` (init + analyze) to current commit SHAs
- Trailing `# v6` / `# v4` comments let Dependabot keep the SHAs bumped

## Test plan
- [ ] CodeQL workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)