### PR TITLE
Wire Drizzle client to Supabase Postgres

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,1 +1,5 @@
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+# Supabase Postgres connection string.
+# Use the Transaction pooler (port 6543) — Cloudflare Workers can't hold
+# persistent connections, and src/db/client.ts sets `prepare: false` to match.
+# Find it in Supabase: Project Settings → Database → Connection string → Transaction.
+DATABASE_URL=postgresql://postgres.[PROJECT-REF]:[PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ npx wrangler dev
 `bun` stays the package manager and is fine for everything else (ingestion
 scripts, type-checking, drizzle-kit). Only the wrangler process needs node.
 
+## Local dev gotcha — `.dev.vars` is not hot-reloaded
+
+`wrangler dev` loads `.dev.vars` once at startup. Editing the file during a
+running session does nothing — the worker keeps the old values (or `undefined`
+for vars added after startup). Restart `wrangler dev` after any `.dev.vars`
+change.
+
 ## MCP transport — manual JSON-RPC dispatch
 
 `src/index.ts` does **not** use `@modelcontextprotocol/sdk`'s `McpServer` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
+import { sql } from "drizzle-orm";
 
+import { createDb } from "./db/client";
 import { getCabinInfo } from "./tools/get-cabin-info";
 import { findQuietCabins } from "./tools/find-quiet-cabins";
 import { compareCabins } from "./tools/compare-cabins";
@@ -79,6 +81,18 @@ app.get("/.well-known/mcp/server.json", (c) =>
     transport: { type: "http", endpoint: "/mcp" },
   }),
 );
+
+app.get("/health/db", async (c) => {
+  const url = c.env.DATABASE_URL;
+  if (!url) return c.json({ ok: false, error: "DATABASE_URL not set" }, 500);
+  try {
+    const db = createDb(url);
+    const rows = await db.execute<{ ok: number }>(sql`select 1 as ok`);
+    return c.json({ ok: rows[0]?.ok === 1 });
+  } catch (e) {
+    return c.json({ ok: false, error: (e as Error).message }, 500);
+  }
+});
 
 app.post("/mcp", async (c) => {
   const body = (await c.req.json()) as JsonRpcRequest;


### PR DESCRIPTION
## Summary
- Document Supabase transaction-pooler `DATABASE_URL` in `.dev.vars.example` — Workers can't hold persistent connections, and `src/db/client.ts` sets `prepare: false` to match pooler transaction mode
- Add `GET /health/db` that runs `SELECT 1` through `src/db/client.ts` — the "trivial query" verification called out in the issue
- `CLAUDE.md`: note that `wrangler dev` doesn't hot-reload `.dev.vars` (have to restart)

Closes #1.

## Test plan
- [x] `curl http://localhost:8787/health/db` returns `{"ok":true}` against the real Supabase project (`uausmffevqrtmetkvslq`)
- [x] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)