### PR TITLE
Wire up initial Drizzle migration + CI apply workflow

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,36 @@
+name: Apply DB migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "migrations/**"
+      - "drizzle.config.ts"
+      - ".github/workflows/migrate.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: db-migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: drizzle-kit migrate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Apply migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: bun run db:migrate

--- a/README.md
+++ b/README.md
@@ -56,6 +56,33 @@ bun run db:migrate    # apply pending migrations to DATABASE_URL
 bun run db:studio     # open Drizzle Studio
 ```
 
+### Migration workflow
+
+Migrations are SQL files in `migrations/`, generated from `src/db/schema.ts` and
+committed to the repo. A migration is applied to a database exactly once —
+drizzle-kit tracks applied migrations in a `__drizzle_migrations` table.
+
+**When making a schema change:**
+
+1. Edit `src/db/schema.ts`.
+2. Run `bun run db:generate`. This writes a new `migrations/NNNN_<name>.sql`
+   plus a snapshot under `migrations/meta/`. Commit both.
+3. Open a PR. Review the generated SQL — rename files are auto-detected but
+   ambiguous renames may be generated as drop+create (data loss).
+4. On merge to `main`, CI applies the migration (see below).
+
+**Applying migrations:**
+
+- **CI (production):** `.github/workflows/migrate.yml` runs `bun run db:migrate`
+  on every push to `main` that touches `migrations/**` or `drizzle.config.ts`.
+  The job runs in the `production` GitHub Environment — set the `DATABASE_URL`
+  secret there, and add a required reviewer on the environment so migrations
+  need an explicit approval click before they apply. Can also be triggered
+  manually from the Actions tab (`workflow_dispatch`).
+- **Local:** `bun run db:migrate` against your own Supabase project /
+  `.dev.vars`. Avoid running this against the shared production database —
+  let CI do it.
+
 ## Status
 
 Scaffolding only. Tool handlers return stub responses. Ingestion pipeline and

--- a/migrations/0000_fresh_dark_beast.sql
+++ b/migrations/0000_fresh_dark_beast.sql
@@ -1,0 +1,57 @@
+CREATE TYPE "public"."adjacency_relationship" AS ENUM('above', 'below', 'adjacent', 'near');--> statement-breakpoint
+CREATE TYPE "public"."amenity_type" AS ENUM('pool', 'theater', 'elevator', 'nightclub', 'buffet', 'restaurant', 'bar', 'lounge', 'spa', 'gym', 'kids_club', 'casino', 'atrium', 'promenade', 'engine_room', 'laundry', 'crew_area', 'other');--> statement-breakpoint
+CREATE TYPE "public"."cabin_category" AS ENUM('inside', 'oceanview', 'balcony', 'suite');--> statement-breakpoint
+CREATE TYPE "public"."cabin_position" AS ENUM('forward', 'mid', 'aft');--> statement-breakpoint
+CREATE TYPE "public"."cabin_side" AS ENUM('port', 'starboard', 'interior');--> statement-breakpoint
+CREATE TABLE "amenities" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"deck_id" uuid NOT NULL,
+	"type" "amenity_type" NOT NULL,
+	"name" text NOT NULL,
+	"position" "cabin_position" NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cabin_adjacencies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"cabin_id" uuid NOT NULL,
+	"amenity_id" uuid NOT NULL,
+	"relationship" "adjacency_relationship" NOT NULL,
+	"distance_score" real NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cabins" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"deck_id" uuid NOT NULL,
+	"number" text NOT NULL,
+	"category" "cabin_category" NOT NULL,
+	"position" "cabin_position" NOT NULL,
+	"side" "cabin_side" NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "decks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"ship_id" uuid NOT NULL,
+	"deck_number" integer NOT NULL,
+	"name" text
+);
+--> statement-breakpoint
+CREATE TABLE "ships" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"cruise_line" text NOT NULL,
+	"class" text
+);
+--> statement-breakpoint
+ALTER TABLE "amenities" ADD CONSTRAINT "amenities_deck_id_decks_id_fk" FOREIGN KEY ("deck_id") REFERENCES "public"."decks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cabin_adjacencies" ADD CONSTRAINT "cabin_adjacencies_cabin_id_cabins_id_fk" FOREIGN KEY ("cabin_id") REFERENCES "public"."cabins"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cabin_adjacencies" ADD CONSTRAINT "cabin_adjacencies_amenity_id_amenities_id_fk" FOREIGN KEY ("amenity_id") REFERENCES "public"."amenities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cabins" ADD CONSTRAINT "cabins_deck_id_decks_id_fk" FOREIGN KEY ("deck_id") REFERENCES "public"."decks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "decks" ADD CONSTRAINT "decks_ship_id_ships_id_fk" FOREIGN KEY ("ship_id") REFERENCES "public"."ships"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "amenities_deck_type_idx" ON "amenities" USING btree ("deck_id","type");--> statement-breakpoint
+CREATE UNIQUE INDEX "cabin_adj_unique" ON "cabin_adjacencies" USING btree ("cabin_id","amenity_id","relationship");--> statement-breakpoint
+CREATE INDEX "cabin_adj_cabin_idx" ON "cabin_adjacencies" USING btree ("cabin_id");--> statement-breakpoint
+CREATE INDEX "cabin_adj_amenity_idx" ON "cabin_adjacencies" USING btree ("amenity_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "cabins_deck_number_uniq" ON "cabins" USING btree ("deck_id","number");--> statement-breakpoint
+CREATE INDEX "cabins_category_idx" ON "cabins" USING btree ("category");--> statement-breakpoint
+CREATE UNIQUE INDEX "decks_ship_number_uniq" ON "decks" USING btree ("ship_id","deck_number");--> statement-breakpoint
+CREATE UNIQUE INDEX "ships_name_line_uniq" ON "ships" USING btree ("name","cruise_line");

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,532 @@
+{
+  "id": "2dbb2112-1363-4fe1-80eb-5eacb674cdc4",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.amenities": {
+      "name": "amenities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "amenity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "cabin_position",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "amenities_deck_type_idx": {
+          "name": "amenities_deck_type_idx",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "amenities_deck_id_decks_id_fk": {
+          "name": "amenities_deck_id_decks_id_fk",
+          "tableFrom": "amenities",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cabin_adjacencies": {
+      "name": "cabin_adjacencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cabin_id": {
+          "name": "cabin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amenity_id": {
+          "name": "amenity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "adjacency_relationship",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance_score": {
+          "name": "distance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cabin_adj_unique": {
+          "name": "cabin_adj_unique",
+          "columns": [
+            {
+              "expression": "cabin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "amenity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "relationship",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabin_adj_cabin_idx": {
+          "name": "cabin_adj_cabin_idx",
+          "columns": [
+            {
+              "expression": "cabin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabin_adj_amenity_idx": {
+          "name": "cabin_adj_amenity_idx",
+          "columns": [
+            {
+              "expression": "amenity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cabin_adjacencies_cabin_id_cabins_id_fk": {
+          "name": "cabin_adjacencies_cabin_id_cabins_id_fk",
+          "tableFrom": "cabin_adjacencies",
+          "tableTo": "cabins",
+          "columnsFrom": [
+            "cabin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cabin_adjacencies_amenity_id_amenities_id_fk": {
+          "name": "cabin_adjacencies_amenity_id_amenities_id_fk",
+          "tableFrom": "cabin_adjacencies",
+          "tableTo": "amenities",
+          "columnsFrom": [
+            "amenity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cabins": {
+      "name": "cabins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "cabin_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "cabin_position",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "cabin_side",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cabins_deck_number_uniq": {
+          "name": "cabins_deck_number_uniq",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabins_category_idx": {
+          "name": "cabins_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cabins_deck_id_decks_id_fk": {
+          "name": "cabins_deck_id_decks_id_fk",
+          "tableFrom": "cabins",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deck_number": {
+          "name": "deck_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "decks_ship_number_uniq": {
+          "name": "decks_ship_number_uniq",
+          "columns": [
+            {
+              "expression": "ship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deck_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decks_ship_id_ships_id_fk": {
+          "name": "decks_ship_id_ships_id_fk",
+          "tableFrom": "decks",
+          "tableTo": "ships",
+          "columnsFrom": [
+            "ship_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ships": {
+      "name": "ships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cruise_line": {
+          "name": "cruise_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ships_name_line_uniq": {
+          "name": "ships_name_line_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cruise_line",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.adjacency_relationship": {
+      "name": "adjacency_relationship",
+      "schema": "public",
+      "values": [
+        "above",
+        "below",
+        "adjacent",
+        "near"
+      ]
+    },
+    "public.amenity_type": {
+      "name": "amenity_type",
+      "schema": "public",
+      "values": [
+        "pool",
+        "theater",
+        "elevator",
+        "nightclub",
+        "buffet",
+        "restaurant",
+        "bar",
+        "lounge",
+        "spa",
+        "gym",
+        "kids_club",
+        "casino",
+        "atrium",
+        "promenade",
+        "engine_room",
+        "laundry",
+        "crew_area",
+        "other"
+      ]
+    },
+    "public.cabin_category": {
+      "name": "cabin_category",
+      "schema": "public",
+      "values": [
+        "inside",
+        "oceanview",
+        "balcony",
+        "suite"
+      ]
+    },
+    "public.cabin_position": {
+      "name": "cabin_position",
+      "schema": "public",
+      "values": [
+        "forward",
+        "mid",
+        "aft"
+      ]
+    },
+    "public.cabin_side": {
+      "name": "cabin_side",
+      "schema": "public",
+      "values": [
+        "port",
+        "starboard",
+        "interior"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1776987030095,
+      "tag": "0000_fresh_dark_beast",
+      "breakpoints": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Generate the initial `migrations/0000_fresh_dark_beast.sql` from `src/db/schema.ts` (5 tables, 5 enums, indexes, FKs).
- Add `.github/workflows/migrate.yml` to run `bun run db:migrate` on push to `main` when `migrations/**` or `drizzle.config.ts` change; also `workflow_dispatch`. Runs in the `production` GitHub Environment so a required reviewer can gate each apply.
- Document the migration workflow in the README (how to generate, commit, review, and apply).

Closes #2.

## Before merging
- Create a `production` environment in repo settings, set `DATABASE_URL` as an environment secret, and add a required reviewer. On merge, approve the workflow run to apply the first migration.

## Test plan
- [ ] `bun run db:generate` produced the migration locally; reviewed SQL matches schema.
- [ ] `bun run typecheck` passes.
- [ ] After merge, approve the `Apply DB migrations` workflow run and confirm the migration applied to Supabase (`__drizzle_migrations` table + 5 new tables).
- [ ] Verify re-running the workflow is a no-op (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)