### PR TITLE
Add PR CI workflow for typecheck and wrangler build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: typecheck + wrangler build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Wrangler build (dry-run)
+        run: npx wrangler deploy --dry-run


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs on `pull_request` to `main`
- Steps: `bun install --frozen-lockfile`, `bun run typecheck`, `npx wrangler deploy --dry-run`
- No deploy and no Cloudflare secrets — `--dry-run` builds the Worker bundle and validates `wrangler.toml` without uploading

Closes #4

## Test plan
- [ ] CI workflow runs on this PR and both steps pass
- [ ] Confirm no `CLOUDFLARE_API_TOKEN` is referenced in the workflow
- [ ] Verify `deploy.yml` is unchanged and still gates real deploys on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)