### PR TITLE
Reshape DB schema for continuous coords and bbox-based spaces

### DIFF
--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -1,0 +1,258 @@
+# Data schema — YAML encoding for cruise ship deck plans
+
+This is the canonical reference for how cruise ship deck plans are encoded
+into YAML files for ingestion into the `cruise-deck-mcp` database. When the
+user pastes a deck screenshot in chat (or shares it via Claude cowork),
+Claude produces YAML matching the rules in this document. The user reviews,
+edits if needed, commits the file, and the seed script (issue #8) loads it
+into Supabase.
+
+This document is **the contract Claude follows when encoding**. If the rules
+need to change, update this file first, then re-encode.
+
+## Layout
+
+```
+data/
+  ships/
+    <slug>/
+      ship.yaml          # ship-level metadata, one per ship
+      deck-1.yaml        # one file per passenger deck
+      deck-2.yaml
+      ...
+```
+
+One file per screenshot. If you paste a deck-8 screenshot, Claude updates
+exactly `data/ships/<slug>/deck-8.yaml` — no other file. This makes
+re-encoding a single deck trivial when a screenshot is wrong or improved.
+
+## Coordinate system
+
+All positions use a normalized percentage system:
+
+- `fore_aft`: **0 = bow** (front of ship), **100 = stern** (back of ship)
+- `port_starboard`: **0 = port** (left when facing bow), **100 = starboard** (right)
+
+Estimate to ~5% precision from the screenshot. Don't agonize — adjacency math
+only needs "close enough." A cabin at `fore_aft: 62` vs `fore_aft: 65` will
+score the same against an overhead nightclub.
+
+Cabins are stored as **points** (single fore_aft + port_starboard). Spaces
+are stored as **bounding boxes** (`fore_aft_min/max`, `port_starboard_min/max`).
+For irregularly-shaped spaces (round atriums, L-shaped pools), the bbox is
+the tightest enclosing rectangle.
+
+## `ship.yaml` schema
+
+One file per ship, at `data/ships/<slug>/ship.yaml`.
+
+```yaml
+slug: disney-fantasy           # required, kebab-case, stable PK / CLI handle
+name: "Disney Fantasy"         # required, human-readable
+cruise_line: "Disney Cruise Line"   # required
+class: "Dream"                 # optional, ship class for sister-ship grouping
+gross_tonnage: 130000          # optional
+year_built: 2012               # optional
+length_m: 340                  # optional, used to sanity-check coordinate scaling
+beam_m: 38                     # optional
+deck_count: 14                 # required, total passenger decks
+notes: ""                      # optional, free text
+```
+
+**Field reference**:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `slug` | string | yes | kebab-case, unique across all ships, also the directory name |
+| `name` | string | yes | as printed by the cruise line |
+| `cruise_line` | string | yes | full name, e.g. "Royal Caribbean International" |
+| `class` | string | no | ship class (Oasis, Quantum, Dream, etc.) for grouping |
+| `gross_tonnage` | int | no | GT, used as a rough size proxy |
+| `year_built` | int | no | year the ship entered service |
+| `length_m` | float | no | overall length in meters |
+| `beam_m` | float | no | maximum width in meters |
+| `deck_count` | int | yes | total number of passenger decks (excludes crew-only) |
+| `notes` | string | no | anything else worth recording |
+
+## `deck-<n>.yaml` schema
+
+One file per passenger deck, at `data/ships/<slug>/deck-<n>.yaml`.
+
+```yaml
+deck: 8                        # required, integer deck number
+name: "Caribbean"              # optional, themed deck name if any
+passenger: true                # required; false for crew-only / mechanical decks
+notes: ""                      # optional
+
+cabins:
+  - number: "8420"             # required, string (preserve leading zeros / letters)
+    category: balcony          # required: interior | oceanview | balcony | suite
+    fore_aft: 62               # required, 0–100
+    port_starboard: 18         # required, 0–100
+    accessible: false          # optional, default false
+    connecting: false          # optional, default false (has connecting door to neighbor)
+    obstructed_view: false     # optional, default false (lifeboat/structure blocks view)
+    notes: ""                  # optional
+
+spaces:
+  - type: nightclub            # required, controlled vocab (see next section)
+    name: "The Tube"           # required if named; "" if generic
+    fore_aft: [40, 55]         # required, [min, max] bbox 0–100
+    port_starboard: [30, 70]   # required, [min, max] bbox 0–100
+    enclosed: true             # required; false for open-air decks/pools
+    noise_level: 70            # required, 0–100; 0 means "no sound emitter" (atrium void, corridor)
+    open_to_above: false       # optional, default false (sound coupling up — atrium roof)
+    open_to_below: false       # optional, default false (sound coupling down)
+    notes: ""                  # optional
+```
+
+**Cabin field reference**:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `number` | string | yes | preserve formatting (`"08420"`, `"8420A"`) |
+| `category` | enum | yes | `interior`, `oceanview`, `balcony`, `suite` |
+| `fore_aft` | float | yes | 0–100 |
+| `port_starboard` | float | yes | 0–100 |
+| `accessible` | bool | no | wheelchair-accessible cabin |
+| `connecting` | bool | no | has a door connecting to a neighboring cabin |
+| `obstructed_view` | bool | no | lifeboat or structure blocks the window/balcony view |
+| `notes` | string | no | anything from the legend that doesn't fit above |
+
+**Space field reference**:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `type` | enum | yes | controlled vocab — see next section |
+| `name` | string | yes | venue's name as printed; `""` if unnamed (e.g. corridor) |
+| `fore_aft` | `[min, max]` | yes | bbox along ship length, 0–100 each |
+| `port_starboard` | `[min, max]` | yes | bbox across beam, 0–100 each |
+| `enclosed` | bool | yes | true for indoor; false for open-air |
+| `noise_level` | int | yes | 0–100, peak-hours score; **0 = non-emitter** |
+| `open_to_above` | bool | no | sound radiates up (atrium top, exposed dome) |
+| `open_to_below` | bool | no | sound radiates down (cutout in floor) |
+| `notes` | string | no | unusual details, time-of-day quirks, etc. |
+
+## `space.type` controlled vocab
+
+The full enum, grouped by typical noise profile. The grouping informs the
+default `noise_level` (next section) but does **not** change the schema —
+all values are siblings in the `space_type` enum.
+
+**Loud** — primary noise emitters, especially during peak hours:
+`nightclub`, `live_music_venue`, `theater`, `showroom`, `arcade`, `casino`,
+`bar`, `lounge`, `pool`, `splash_zone`, `waterslide`, `kids_club`,
+`teen_club`, `sports_court`, `atrium`
+
+**Medium** — moderate noise during meal/operating hours:
+`main_dining_room`, `specialty_dining`, `buffet`, `cafe`, `shops`,
+`photo_studio`, `reception`, `guest_services`
+
+**Quiet** — designed to be calm:
+`spa`, `gym`, `library`, `chapel`, `conference_room`, `lecture_hall`,
+`art_gallery`, `observation_lounge`, `medical`, `adults_only_lounge`
+
+**Functional** — utility spaces; usually quiet but mechanical hum:
+`elevator_bank`, `stairs`, `corridor`, `crew_area`, `galley`, `mechanical`,
+`laundry`, `restroom`, `storage`
+
+**Exterior** — open-deck areas; sound dissipates outdoors:
+`open_deck`, `sun_deck`, `promenade`, `jogging_track`, `helipad`
+
+**Catch-all**: `other` — must populate `notes` describing the space.
+Treated as medium noise unless overridden.
+
+## `noise_level` defaults by type
+
+When encoding, Claude starts from the default for the type, then adjusts per
+cruise-line and per-venue (see next sections). The user can override any
+value if they have specific knowledge.
+
+| Bucket | Types | Default `noise_level` |
+|---|---|---|
+| Loud | `nightclub`, `live_music_venue` | 85 |
+| Loud | `theater`, `showroom`, `arcade`, `casino` | 75 |
+| Loud | `bar`, `lounge`, `pool`, `splash_zone`, `waterslide`, `kids_club`, `teen_club`, `sports_court`, `atrium` | 70 |
+| Medium | `main_dining_room`, `specialty_dining`, `buffet`, `cafe` | 50 |
+| Medium | `shops`, `reception`, `guest_services`, `photo_studio` | 40 |
+| Quiet | `gym`, `adults_only_lounge`, `observation_lounge` | 30 |
+| Quiet | `spa`, `library`, `chapel`, `art_gallery`, `lecture_hall`, `conference_room`, `medical` | 15 |
+| Functional | `elevator_bank`, `stairs`, `corridor` | 25 |
+| Functional | `crew_area`, `galley`, `mechanical`, `laundry`, `restroom`, `storage` | 20 |
+| Exterior | `open_deck`, `sun_deck`, `promenade`, `jogging_track` | 35 |
+| Exterior | `helipad` | 50 |
+| Catch-all | `other` | 50 |
+
+Any space with no actual sound source (atrium void on a non-emitter deck,
+empty corridors, structural shafts) gets `noise_level: 0` regardless of its
+type bucket. This keeps the noise scorer from double-counting multi-deck
+spaces (see "Encoding rules" below).
+
+## Cruise-line shift heuristics
+
+Same `type`, same default — but a Disney nightclub really is quieter than a
+Carnival one. Apply this shift to the type default, then clamp to 0–100:
+
+| Cruise lines | Shift |
+|---|---|
+| Disney, Cunard, Viking, Princess, Holland America | **−15** |
+| Royal Caribbean, NCL, Celebrity, Costa, Oceania | **±0** |
+| Carnival, Virgin, MSC, P&O | **+10** |
+
+Then per-venue: if Claude recognizes the venue name (e.g. an adults-only
+lounge known to be quiet, a "rock" club known to be loud), adjust ±5–15
+on top.
+
+## Encoding rules
+
+When Claude produces YAML from a deck screenshot:
+
+1. **One file per screenshot.** If you paste deck 8, only `deck-8.yaml` is
+   touched. No cross-deck synthesis.
+
+2. **Don't invent data.** If a venue's name isn't legible, leave `name: ""`
+   and put what's visible in `notes`. If a cabin number is partly cut off,
+   skip the cabin rather than guess.
+
+3. **Multi-deck spaces** (atriums, theaters that breach two decks): list the
+   space on **every deck where its footprint is visible on the screenshot**,
+   so `get_deck_layout` reports the right thing per deck. Set `noise_level:
+   0` on the void decks (the atrium "hole") and `noise_level: <real value>`
+   on the deck where the actual sound source lives (the band, the bar, the
+   stage). This prevents double-counting in the noise scorer while still
+   capturing layout accurately.
+
+4. **Bbox over centroids.** Every space gets a bounding box. For round or
+   irregular shapes, use the tightest enclosing rectangle. Cabins are
+   points, not boxes — they're small enough that a point is fine for
+   adjacency math.
+
+5. **Unknown deck name → omit the field**, don't guess.
+
+6. **Estimate to ~5% precision.** A balcony cabin at `fore_aft: 62` vs `65`
+   produces the same noise score against an overhead theater. Don't spend
+   effort being more precise than the model can use.
+
+7. **List every visible space**, including corridors, restrooms, elevator
+   banks, and storage. They contribute to layout queries ("walk distance to
+   nearest elevator") even when their `noise_level` is low.
+
+## Mapping to the database
+
+The seed script (`ingestion/seed.ts`, issue #8) reads these YAML files and
+inserts rows into the database tables defined in `src/db/schema.ts`. The
+shape is mostly 1:1:
+
+| YAML | DB table | Notes |
+|---|---|---|
+| `ship.yaml` | `ships` (one row) | `slug` is unique |
+| `deck-<n>.yaml` (top-level) | `decks` (one row per file) | `passenger` defaults true |
+| `cabins[]` | `cabins` | `fore_aft`, `port_starboard` real columns |
+| `spaces[]` | `spaces` | bbox stored as four real columns; `noise_level` int |
+
+**Derived (not encoded in YAML)**: `cabin_space_proximity`. The seed script
+computes this by stacking decks: for each cabin, find spaces within
+`|vertical_decks| ≤ 3` and `horizontal_distance ≤ 30` (point-to-bbox
+euclidean distance), insert one row per pair. The noise scoring algorithm
+(`src/scoring/noise-score.ts`, issue #14) then aggregates over these rows
+at query time using the formula it carries.

--- a/ingestion/extract.ts
+++ b/ingestion/extract.ts
@@ -1,10 +1,9 @@
-// Deck plan extraction — to be implemented in a separate phase.
-// Input: PDF / image of a cruise ship deck plan.
-// Output: structured JSON conforming to src/db/schema.ts entities, ready for
-// insertion via ingestion/seed.ts.
-//
-// Plan: send the image(s) to Claude (Anthropic API) with a structured prompt
-// asking it to enumerate decks, cabins, and amenities with positions.
+// V1 of this project does NOT use an automated extractor. Deck plans are
+// encoded interactively: the user pastes a deck screenshot in chat, Claude
+// emits per-deck YAML matching `docs/data-schema.md`, and the user commits
+// it under `data/ships/<slug>/`. This file is kept as a placeholder for a
+// future automated path (e.g. Claude API + structured prompt) but is not
+// part of the v1 ingestion pipeline.
 
 export async function extractDeckPlan(_path: string): Promise<unknown> {
   throw new Error("deck plan extraction not yet implemented");

--- a/migrations/0001_continuous_coords_bbox_spaces.sql
+++ b/migrations/0001_continuous_coords_bbox_spaces.sql
@@ -1,0 +1,69 @@
+CREATE TYPE "public"."space_type" AS ENUM('nightclub', 'live_music_venue', 'theater', 'showroom', 'arcade', 'casino', 'bar', 'lounge', 'pool', 'splash_zone', 'waterslide', 'kids_club', 'teen_club', 'sports_court', 'atrium', 'main_dining_room', 'specialty_dining', 'buffet', 'cafe', 'shops', 'photo_studio', 'reception', 'guest_services', 'spa', 'gym', 'library', 'chapel', 'conference_room', 'lecture_hall', 'art_gallery', 'observation_lounge', 'medical', 'adults_only_lounge', 'elevator_bank', 'stairs', 'corridor', 'crew_area', 'galley', 'mechanical', 'laundry', 'restroom', 'storage', 'open_deck', 'sun_deck', 'promenade', 'jogging_track', 'helipad', 'other');--> statement-breakpoint
+CREATE TABLE "cabin_space_proximity" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"cabin_id" uuid NOT NULL,
+	"space_id" uuid NOT NULL,
+	"vertical_decks" integer NOT NULL,
+	"horizontal_distance" real NOT NULL,
+	CONSTRAINT "proximity_horizontal_distance_range" CHECK ("cabin_space_proximity"."horizontal_distance" BETWEEN 0 AND 100),
+	CONSTRAINT "proximity_vertical_decks_range" CHECK ("cabin_space_proximity"."vertical_decks" BETWEEN -50 AND 50)
+);
+--> statement-breakpoint
+CREATE TABLE "spaces" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"deck_id" uuid NOT NULL,
+	"type" "space_type" NOT NULL,
+	"name" text NOT NULL,
+	"fore_aft_min" real NOT NULL,
+	"fore_aft_max" real NOT NULL,
+	"port_starboard_min" real NOT NULL,
+	"port_starboard_max" real NOT NULL,
+	"noise_level" integer NOT NULL,
+	"enclosed" boolean DEFAULT true NOT NULL,
+	"open_to_above" boolean DEFAULT false NOT NULL,
+	"open_to_below" boolean DEFAULT false NOT NULL,
+	"notes" text,
+	CONSTRAINT "spaces_fore_aft_bbox" CHECK ("spaces"."fore_aft_min" <= "spaces"."fore_aft_max" AND "spaces"."fore_aft_min" >= 0 AND "spaces"."fore_aft_max" <= 100),
+	CONSTRAINT "spaces_port_starboard_bbox" CHECK ("spaces"."port_starboard_min" <= "spaces"."port_starboard_max" AND "spaces"."port_starboard_min" >= 0 AND "spaces"."port_starboard_max" <= 100),
+	CONSTRAINT "spaces_noise_level_range" CHECK ("spaces"."noise_level" BETWEEN 0 AND 100)
+);
+--> statement-breakpoint
+ALTER TABLE "amenities" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "cabin_adjacencies" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "amenities" CASCADE;--> statement-breakpoint
+DROP TABLE "cabin_adjacencies" CASCADE;--> statement-breakpoint
+ALTER TABLE "cabins" ALTER COLUMN "category" SET DATA TYPE text;--> statement-breakpoint
+DROP TYPE "public"."cabin_category";--> statement-breakpoint
+CREATE TYPE "public"."cabin_category" AS ENUM('interior', 'oceanview', 'balcony', 'suite');--> statement-breakpoint
+ALTER TABLE "cabins" ALTER COLUMN "category" SET DATA TYPE "public"."cabin_category" USING "category"::"public"."cabin_category";--> statement-breakpoint
+ALTER TABLE "cabins" ADD COLUMN "fore_aft" real NOT NULL;--> statement-breakpoint
+ALTER TABLE "cabins" ADD COLUMN "port_starboard" real NOT NULL;--> statement-breakpoint
+ALTER TABLE "cabins" ADD COLUMN "accessible" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "cabins" ADD COLUMN "connecting" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "cabins" ADD COLUMN "obstructed_view" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "cabins" ADD COLUMN "notes" text;--> statement-breakpoint
+ALTER TABLE "decks" ADD COLUMN "passenger" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "slug" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "gross_tonnage" integer;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "year_built" integer;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "length_m" real;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "beam_m" real;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "deck_count" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "ships" ADD COLUMN "notes" text;--> statement-breakpoint
+ALTER TABLE "cabin_space_proximity" ADD CONSTRAINT "cabin_space_proximity_cabin_id_cabins_id_fk" FOREIGN KEY ("cabin_id") REFERENCES "public"."cabins"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cabin_space_proximity" ADD CONSTRAINT "cabin_space_proximity_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "spaces" ADD CONSTRAINT "spaces_deck_id_decks_id_fk" FOREIGN KEY ("deck_id") REFERENCES "public"."decks"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "cabin_space_proximity_uniq" ON "cabin_space_proximity" USING btree ("cabin_id","space_id");--> statement-breakpoint
+CREATE INDEX "cabin_space_proximity_cabin_idx" ON "cabin_space_proximity" USING btree ("cabin_id");--> statement-breakpoint
+CREATE INDEX "cabin_space_proximity_space_idx" ON "cabin_space_proximity" USING btree ("space_id");--> statement-breakpoint
+CREATE INDEX "cabin_space_proximity_space_vertical_idx" ON "cabin_space_proximity" USING btree ("space_id","vertical_decks");--> statement-breakpoint
+CREATE INDEX "spaces_deck_type_idx" ON "spaces" USING btree ("deck_id","type");--> statement-breakpoint
+CREATE UNIQUE INDEX "ships_slug_uniq" ON "ships" USING btree ("slug");--> statement-breakpoint
+ALTER TABLE "cabins" DROP COLUMN "position";--> statement-breakpoint
+ALTER TABLE "cabins" DROP COLUMN "side";--> statement-breakpoint
+ALTER TABLE "cabins" ADD CONSTRAINT "cabins_fore_aft_range" CHECK ("cabins"."fore_aft" BETWEEN 0 AND 100);--> statement-breakpoint
+ALTER TABLE "cabins" ADD CONSTRAINT "cabins_port_starboard_range" CHECK ("cabins"."port_starboard" BETWEEN 0 AND 100);--> statement-breakpoint
+DROP TYPE "public"."adjacency_relationship";--> statement-breakpoint
+DROP TYPE "public"."amenity_type";--> statement-breakpoint
+DROP TYPE "public"."cabin_position";--> statement-breakpoint
+DROP TYPE "public"."cabin_side";

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,718 @@
+{
+  "id": "47a5d38f-bfef-42d3-9142-f81a263583a2",
+  "prevId": "2dbb2112-1363-4fe1-80eb-5eacb674cdc4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cabin_space_proximity": {
+      "name": "cabin_space_proximity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cabin_id": {
+          "name": "cabin_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vertical_decks": {
+          "name": "vertical_decks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "horizontal_distance": {
+          "name": "horizontal_distance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "cabin_space_proximity_uniq": {
+          "name": "cabin_space_proximity_uniq",
+          "columns": [
+            {
+              "expression": "cabin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabin_space_proximity_cabin_idx": {
+          "name": "cabin_space_proximity_cabin_idx",
+          "columns": [
+            {
+              "expression": "cabin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabin_space_proximity_space_idx": {
+          "name": "cabin_space_proximity_space_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabin_space_proximity_space_vertical_idx": {
+          "name": "cabin_space_proximity_space_vertical_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vertical_decks",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cabin_space_proximity_cabin_id_cabins_id_fk": {
+          "name": "cabin_space_proximity_cabin_id_cabins_id_fk",
+          "tableFrom": "cabin_space_proximity",
+          "tableTo": "cabins",
+          "columnsFrom": [
+            "cabin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cabin_space_proximity_space_id_spaces_id_fk": {
+          "name": "cabin_space_proximity_space_id_spaces_id_fk",
+          "tableFrom": "cabin_space_proximity",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "proximity_horizontal_distance_range": {
+          "name": "proximity_horizontal_distance_range",
+          "value": "\"cabin_space_proximity\".\"horizontal_distance\" BETWEEN 0 AND 100"
+        },
+        "proximity_vertical_decks_range": {
+          "name": "proximity_vertical_decks_range",
+          "value": "\"cabin_space_proximity\".\"vertical_decks\" BETWEEN -50 AND 50"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cabins": {
+      "name": "cabins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "cabin_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fore_aft": {
+          "name": "fore_aft",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port_starboard": {
+          "name": "port_starboard",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessible": {
+          "name": "accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connecting": {
+          "name": "connecting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "obstructed_view": {
+          "name": "obstructed_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cabins_deck_number_uniq": {
+          "name": "cabins_deck_number_uniq",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cabins_category_idx": {
+          "name": "cabins_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cabins_deck_id_decks_id_fk": {
+          "name": "cabins_deck_id_decks_id_fk",
+          "tableFrom": "cabins",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cabins_fore_aft_range": {
+          "name": "cabins_fore_aft_range",
+          "value": "\"cabins\".\"fore_aft\" BETWEEN 0 AND 100"
+        },
+        "cabins_port_starboard_range": {
+          "name": "cabins_port_starboard_range",
+          "value": "\"cabins\".\"port_starboard\" BETWEEN 0 AND 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.decks": {
+      "name": "decks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ship_id": {
+          "name": "ship_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deck_number": {
+          "name": "deck_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passenger": {
+          "name": "passenger",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "decks_ship_number_uniq": {
+          "name": "decks_ship_number_uniq",
+          "columns": [
+            {
+              "expression": "ship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deck_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "decks_ship_id_ships_id_fk": {
+          "name": "decks_ship_id_ships_id_fk",
+          "tableFrom": "decks",
+          "tableTo": "ships",
+          "columnsFrom": [
+            "ship_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ships": {
+      "name": "ships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cruise_line": {
+          "name": "cruise_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_tonnage": {
+          "name": "gross_tonnage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_built": {
+          "name": "year_built",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_m": {
+          "name": "length_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beam_m": {
+          "name": "beam_m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deck_count": {
+          "name": "deck_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ships_slug_uniq": {
+          "name": "ships_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ships_name_line_uniq": {
+          "name": "ships_name_line_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cruise_line",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deck_id": {
+          "name": "deck_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "space_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fore_aft_min": {
+          "name": "fore_aft_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fore_aft_max": {
+          "name": "fore_aft_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port_starboard_min": {
+          "name": "port_starboard_min",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port_starboard_max": {
+          "name": "port_starboard_max",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noise_level": {
+          "name": "noise_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enclosed": {
+          "name": "enclosed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "open_to_above": {
+          "name": "open_to_above",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "open_to_below": {
+          "name": "open_to_below",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "spaces_deck_type_idx": {
+          "name": "spaces_deck_type_idx",
+          "columns": [
+            {
+              "expression": "deck_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_deck_id_decks_id_fk": {
+          "name": "spaces_deck_id_decks_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "decks",
+          "columnsFrom": [
+            "deck_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "spaces_fore_aft_bbox": {
+          "name": "spaces_fore_aft_bbox",
+          "value": "\"spaces\".\"fore_aft_min\" <= \"spaces\".\"fore_aft_max\" AND \"spaces\".\"fore_aft_min\" >= 0 AND \"spaces\".\"fore_aft_max\" <= 100"
+        },
+        "spaces_port_starboard_bbox": {
+          "name": "spaces_port_starboard_bbox",
+          "value": "\"spaces\".\"port_starboard_min\" <= \"spaces\".\"port_starboard_max\" AND \"spaces\".\"port_starboard_min\" >= 0 AND \"spaces\".\"port_starboard_max\" <= 100"
+        },
+        "spaces_noise_level_range": {
+          "name": "spaces_noise_level_range",
+          "value": "\"spaces\".\"noise_level\" BETWEEN 0 AND 100"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.cabin_category": {
+      "name": "cabin_category",
+      "schema": "public",
+      "values": [
+        "interior",
+        "oceanview",
+        "balcony",
+        "suite"
+      ]
+    },
+    "public.space_type": {
+      "name": "space_type",
+      "schema": "public",
+      "values": [
+        "nightclub",
+        "live_music_venue",
+        "theater",
+        "showroom",
+        "arcade",
+        "casino",
+        "bar",
+        "lounge",
+        "pool",
+        "splash_zone",
+        "waterslide",
+        "kids_club",
+        "teen_club",
+        "sports_court",
+        "atrium",
+        "main_dining_room",
+        "specialty_dining",
+        "buffet",
+        "cafe",
+        "shops",
+        "photo_studio",
+        "reception",
+        "guest_services",
+        "spa",
+        "gym",
+        "library",
+        "chapel",
+        "conference_room",
+        "lecture_hall",
+        "art_gallery",
+        "observation_lounge",
+        "medical",
+        "adults_only_lounge",
+        "elevator_bank",
+        "stairs",
+        "corridor",
+        "crew_area",
+        "galley",
+        "mechanical",
+        "laundry",
+        "restroom",
+        "storage",
+        "open_deck",
+        "sun_deck",
+        "promenade",
+        "jogging_track",
+        "helipad",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776987030095,
       "tag": "0000_fresh_dark_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777813495818,
+      "tag": "0001_continuous_coords_bbox_spaces",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,67 +5,94 @@ import {
   text,
   integer,
   real,
+  boolean,
   uniqueIndex,
   index,
+  check,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 export const cabinCategoryEnum = pgEnum("cabin_category", [
-  "inside",
+  "interior",
   "oceanview",
   "balcony",
   "suite",
 ]);
 
-export const cabinPositionEnum = pgEnum("cabin_position", [
-  "forward",
-  "mid",
-  "aft",
-]);
-
-export const cabinSideEnum = pgEnum("cabin_side", [
-  "port",
-  "starboard",
-  "interior",
-]);
-
-export const amenityTypeEnum = pgEnum("amenity_type", [
-  "pool",
-  "theater",
-  "elevator",
+export const spaceTypeEnum = pgEnum("space_type", [
+  // loud
   "nightclub",
-  "buffet",
-  "restaurant",
+  "live_music_venue",
+  "theater",
+  "showroom",
+  "arcade",
+  "casino",
   "bar",
   "lounge",
+  "pool",
+  "splash_zone",
+  "waterslide",
+  "kids_club",
+  "teen_club",
+  "sports_court",
+  "atrium",
+  // medium
+  "main_dining_room",
+  "specialty_dining",
+  "buffet",
+  "cafe",
+  "shops",
+  "photo_studio",
+  "reception",
+  "guest_services",
+  // quiet
   "spa",
   "gym",
-  "kids_club",
-  "casino",
-  "atrium",
-  "promenade",
-  "engine_room",
-  "laundry",
+  "library",
+  "chapel",
+  "conference_room",
+  "lecture_hall",
+  "art_gallery",
+  "observation_lounge",
+  "medical",
+  "adults_only_lounge",
+  // functional
+  "elevator_bank",
+  "stairs",
+  "corridor",
   "crew_area",
+  "galley",
+  "mechanical",
+  "laundry",
+  "restroom",
+  "storage",
+  // exterior
+  "open_deck",
+  "sun_deck",
+  "promenade",
+  "jogging_track",
+  "helipad",
+  // catch-all
   "other",
-]);
-
-export const adjacencyRelationshipEnum = pgEnum("adjacency_relationship", [
-  "above",
-  "below",
-  "adjacent",
-  "near",
 ]);
 
 export const ships = pgTable(
   "ships",
   {
     id: uuid("id").primaryKey().defaultRandom(),
+    slug: text("slug").notNull(),
     name: text("name").notNull(),
     cruiseLine: text("cruise_line").notNull(),
     class: text("class"),
+    grossTonnage: integer("gross_tonnage"),
+    yearBuilt: integer("year_built"),
+    lengthM: real("length_m"),
+    beamM: real("beam_m"),
+    deckCount: integer("deck_count").notNull(),
+    notes: text("notes"),
   },
   (t) => ({
+    slugUnique: uniqueIndex("ships_slug_uniq").on(t.slug),
     nameLineUnique: uniqueIndex("ships_name_line_uniq").on(t.name, t.cruiseLine),
   }),
 );
@@ -79,6 +106,7 @@ export const decks = pgTable(
       .references(() => ships.id, { onDelete: "cascade" }),
     deckNumber: integer("deck_number").notNull(),
     name: text("name"),
+    passenger: boolean("passenger").notNull().default(true),
   },
   (t) => ({
     shipDeckUnique: uniqueIndex("decks_ship_number_uniq").on(
@@ -97,8 +125,12 @@ export const cabins = pgTable(
       .references(() => decks.id, { onDelete: "cascade" }),
     number: text("number").notNull(),
     category: cabinCategoryEnum("category").notNull(),
-    position: cabinPositionEnum("position").notNull(),
-    side: cabinSideEnum("side").notNull(),
+    foreAft: real("fore_aft").notNull(),
+    portStarboard: real("port_starboard").notNull(),
+    accessible: boolean("accessible").notNull().default(false),
+    connecting: boolean("connecting").notNull().default(false),
+    obstructedView: boolean("obstructed_view").notNull().default(false),
+    notes: text("notes"),
   },
   (t) => ({
     deckNumberUnique: uniqueIndex("cabins_deck_number_uniq").on(
@@ -106,46 +138,85 @@ export const cabins = pgTable(
       t.number,
     ),
     categoryIdx: index("cabins_category_idx").on(t.category),
+    foreAftRange: check(
+      "cabins_fore_aft_range",
+      sql`${t.foreAft} BETWEEN 0 AND 100`,
+    ),
+    portStarboardRange: check(
+      "cabins_port_starboard_range",
+      sql`${t.portStarboard} BETWEEN 0 AND 100`,
+    ),
   }),
 );
 
-export const amenities = pgTable(
-  "amenities",
+export const spaces = pgTable(
+  "spaces",
   {
     id: uuid("id").primaryKey().defaultRandom(),
     deckId: uuid("deck_id")
       .notNull()
       .references(() => decks.id, { onDelete: "cascade" }),
-    type: amenityTypeEnum("type").notNull(),
+    type: spaceTypeEnum("type").notNull(),
     name: text("name").notNull(),
-    position: cabinPositionEnum("position").notNull(),
+    foreAftMin: real("fore_aft_min").notNull(),
+    foreAftMax: real("fore_aft_max").notNull(),
+    portStarboardMin: real("port_starboard_min").notNull(),
+    portStarboardMax: real("port_starboard_max").notNull(),
+    noiseLevel: integer("noise_level").notNull(),
+    enclosed: boolean("enclosed").notNull().default(true),
+    openToAbove: boolean("open_to_above").notNull().default(false),
+    openToBelow: boolean("open_to_below").notNull().default(false),
+    notes: text("notes"),
   },
   (t) => ({
-    deckTypeIdx: index("amenities_deck_type_idx").on(t.deckId, t.type),
+    deckTypeIdx: index("spaces_deck_type_idx").on(t.deckId, t.type),
+    foreAftBbox: check(
+      "spaces_fore_aft_bbox",
+      sql`${t.foreAftMin} <= ${t.foreAftMax} AND ${t.foreAftMin} >= 0 AND ${t.foreAftMax} <= 100`,
+    ),
+    portStarboardBbox: check(
+      "spaces_port_starboard_bbox",
+      sql`${t.portStarboardMin} <= ${t.portStarboardMax} AND ${t.portStarboardMin} >= 0 AND ${t.portStarboardMax} <= 100`,
+    ),
+    noiseLevelRange: check(
+      "spaces_noise_level_range",
+      sql`${t.noiseLevel} BETWEEN 0 AND 100`,
+    ),
   }),
 );
 
-export const cabinAdjacencies = pgTable(
-  "cabin_adjacencies",
+export const cabinSpaceProximity = pgTable(
+  "cabin_space_proximity",
   {
     id: uuid("id").primaryKey().defaultRandom(),
     cabinId: uuid("cabin_id")
       .notNull()
       .references(() => cabins.id, { onDelete: "cascade" }),
-    amenityId: uuid("amenity_id")
+    spaceId: uuid("space_id")
       .notNull()
-      .references(() => amenities.id, { onDelete: "cascade" }),
-    relationship: adjacencyRelationshipEnum("relationship").notNull(),
-    distanceScore: real("distance_score").notNull(),
+      .references(() => spaces.id, { onDelete: "cascade" }),
+    verticalDecks: integer("vertical_decks").notNull(),
+    horizontalDistance: real("horizontal_distance").notNull(),
   },
   (t) => ({
-    cabinAmenityRelUnique: uniqueIndex("cabin_adj_unique").on(
+    cabinSpaceUnique: uniqueIndex("cabin_space_proximity_uniq").on(
       t.cabinId,
-      t.amenityId,
-      t.relationship,
+      t.spaceId,
     ),
-    cabinIdx: index("cabin_adj_cabin_idx").on(t.cabinId),
-    amenityIdx: index("cabin_adj_amenity_idx").on(t.amenityId),
+    cabinIdx: index("cabin_space_proximity_cabin_idx").on(t.cabinId),
+    spaceIdx: index("cabin_space_proximity_space_idx").on(t.spaceId),
+    spaceVerticalIdx: index("cabin_space_proximity_space_vertical_idx").on(
+      t.spaceId,
+      t.verticalDecks,
+    ),
+    horizontalDistanceRange: check(
+      "proximity_horizontal_distance_range",
+      sql`${t.horizontalDistance} BETWEEN 0 AND 100`,
+    ),
+    verticalDecksRange: check(
+      "proximity_vertical_decks_range",
+      sql`${t.verticalDecks} BETWEEN -50 AND 50`,
+    ),
   }),
 );
 
@@ -156,29 +227,29 @@ export const shipsRelations = relations(ships, ({ many }) => ({
 export const decksRelations = relations(decks, ({ one, many }) => ({
   ship: one(ships, { fields: [decks.shipId], references: [ships.id] }),
   cabins: many(cabins),
-  amenities: many(amenities),
+  spaces: many(spaces),
 }));
 
 export const cabinsRelations = relations(cabins, ({ one, many }) => ({
   deck: one(decks, { fields: [cabins.deckId], references: [decks.id] }),
-  adjacencies: many(cabinAdjacencies),
+  proximities: many(cabinSpaceProximity),
 }));
 
-export const amenitiesRelations = relations(amenities, ({ one, many }) => ({
-  deck: one(decks, { fields: [amenities.deckId], references: [decks.id] }),
-  adjacencies: many(cabinAdjacencies),
+export const spacesRelations = relations(spaces, ({ one, many }) => ({
+  deck: one(decks, { fields: [spaces.deckId], references: [decks.id] }),
+  proximities: many(cabinSpaceProximity),
 }));
 
-export const cabinAdjacenciesRelations = relations(
-  cabinAdjacencies,
+export const cabinSpaceProximityRelations = relations(
+  cabinSpaceProximity,
   ({ one }) => ({
     cabin: one(cabins, {
-      fields: [cabinAdjacencies.cabinId],
+      fields: [cabinSpaceProximity.cabinId],
       references: [cabins.id],
     }),
-    amenity: one(amenities, {
-      fields: [cabinAdjacencies.amenityId],
-      references: [amenities.id],
+    space: one(spaces, {
+      fields: [cabinSpaceProximity.spaceId],
+      references: [spaces.id],
     }),
   }),
 );
@@ -186,5 +257,5 @@ export const cabinAdjacenciesRelations = relations(
 export type Ship = typeof ships.$inferSelect;
 export type Deck = typeof decks.$inferSelect;
 export type Cabin = typeof cabins.$inferSelect;
-export type Amenity = typeof amenities.$inferSelect;
-export type CabinAdjacency = typeof cabinAdjacencies.$inferSelect;
+export type Space = typeof spaces.$inferSelect;
+export type CabinSpaceProximity = typeof cabinSpaceProximity.$inferSelect;

--- a/src/scoring/noise-score.ts
+++ b/src/scoring/noise-score.ts
@@ -1,7 +1,8 @@
 // Noise scoring algorithm — to be implemented in a separate phase.
-// Inputs: a cabin and its adjacencies to noisy amenities (pools, theaters,
-// nightclubs, elevators, engine rooms, etc.) along with relationship
-// (above/below/adjacent/near) and distance scores.
+// Inputs: a cabin and its `cabin_space_proximity` rows joined to `spaces`.
+// Each row carries `vertical_decks` (signed deck offset) and
+// `horizontal_distance` (point-to-bbox, 0–100), and the joined space supplies
+// `noise_level` (0–100), `enclosed`, `open_to_above`, `open_to_below`.
 //
 // Output: a numeric quietness score and a breakdown of contributing factors.
 
@@ -9,8 +10,9 @@ export interface NoiseScore {
   cabinId: string;
   score: number;
   factors: Array<{
-    amenityType: string;
-    relationship: string;
+    spaceType: string;
+    verticalDecks: number;
+    horizontalDistance: number;
     contribution: number;
   }>;
 }

--- a/src/tools/get-deck-layout.ts
+++ b/src/tools/get-deck-layout.ts
@@ -1,6 +1,6 @@
 export const getDeckLayout = {
   name: "get_deck_layout",
-  description: "Return the layout of a single deck — cabins and amenities.",
+  description: "Return the layout of a single deck — cabins and spaces.",
   inputSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary

- Replace bucketed cabin/amenity positions (`forward/mid/aft`, single-position enums) with continuous `fore_aft`/`port_starboard` on `cabins` and bbox columns on `spaces` (renamed from `amenities`). The bucketed model couldn't answer point-to-bbox distance queries, which every noise-scoring question reduces to.
- Add `noise_level` (0–100, per-instance), `enclosed`, `open_to_above`, `open_to_below` to `spaces` so a Disney club ≠ a Carnival club, and so multi-deck atriums can be modeled correctly (void decks get `noise_level: 0` so the scorer doesn't double-count).
- Replace `cabin_adjacencies` with **`cabin_space_proximity`**: stores geometric primitives only (`vertical_decks` signed int, `horizontal_distance` real). The noise-scoring formula stays in TS (`src/scoring/noise-score.ts`) so it can iterate without re-seeding.
- Add `docs/data-schema.md` — the canonical YAML encoding contract for the v1 interactive workflow (user pastes deck screenshots in chat → Claude emits per-deck YAML → user commits → seed script ingests).

Schema details, including the full `space_type` controlled vocab (~50 values grouped by noise profile), CHECK constraints on every coordinate range, and `noise_level` defaults by type are in `docs/data-schema.md`.

## Migration

`migrations/0001_continuous_coords_bbox_spaces.sql` — single reshape migration. Database has zero rows, so it's a clean drop+create for changed tables/enums and column-level ADD/DROP for `cabins`/`ships`/`decks`. The deploy workflow already runs `bun run db:migrate` before `wrangler deploy` under production-environment approval, so merging will apply it.

## Issue cleanup (separate from this PR)

Already done on the issue tracker:
- Closed #6 (PDF extractor) and #9 (review workflow) — superseded by interactive encoding.
- Updated #7 (normalization), #8 (seed script), #14 (noise scoring) bodies to match the new architecture.

## Test plan

- [ ] CI typecheck job passes (`tsc --noEmit`).
- [ ] CI `wrangler deploy --dry-run` job passes.
- [ ] Approve `migrate` job under the `production` environment; confirm it applies `0001_continuous_coords_bbox_spaces` (drizzle journal shows both 0000 and 0001).
- [ ] Approve `deploy` job; confirm Worker redeploys.
- [ ] `curl https://<worker-host>/health/db` returns `{"ok":true}` after deploy.
- [ ] Re-running the migrate job is a no-op (drizzle journal unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)