### PR TITLE
Add normalization layer for extracted deck YAML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,31 @@ Each tool lives in `src/tools/<name>.ts` and exports `{ name, description,
 inputSchema, handler }`. JSON Schema is written by hand for the `inputSchema`;
 zod is in deps for runtime arg validation when handlers stop being stubs.
 
+## Ingestion
+
+`ingestion/normalize.ts` is the thin layer between the YAML files under
+`data/ships/<slug>/` and the database. It validates with zod (schemas mirror
+`docs/data-schema.md`), maps to row-shaped output for `ships`/`decks`/
+`cabins`/`spaces`, and derives `cabin_space_proximity` rows via point-to-bbox
+euclidean distance (cutoffs `|vertical_decks| ≤ 3`, `horizontal_distance ≤ 30`).
+Cross-table FKs in the output use natural keys (deck number, cabin number,
+space `localIndex`) — UUIDs are generated at insert time, so the seed script
+resolves keys to ids per table.
+
+Run standalone to inspect output for one ship:
+
+```bash
+bun run ingestion/normalize.ts data/ships/<slug>
+```
+
+`ingestion/extract.ts` is a placeholder — v1 has no automated extractor;
+encoding happens interactively (paste screenshot → Claude emits YAML → user
+commits).
+
 ## Status
 
-Scaffolding only. The four tools all return `STUB:` text. Ingestion
-(`ingestion/extract.ts`, `ingestion/seed.ts`) and noise scoring
+Scaffolding plus a normalization layer. The four tools all return `STUB:` text.
+The seed script (`ingestion/seed.ts`) and noise scoring
 (`src/scoring/noise-score.ts`) are explicit next phases — don't expand them
 without the user asking.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ src/
   tools/              MCP tool handlers (stubs)
   db/                 Drizzle schema + Supabase client
   scoring/            Noise scoring logic (TBD)
-ingestion/            PDF/image → structured data (TBD, runs locally)
+ingestion/            YAML → row-shaped data → seed (runs locally under Bun)
 migrations/           Drizzle-generated SQL migrations
 .well-known/mcp/      MCP registry discovery
 ```
@@ -147,7 +147,28 @@ at runtime.
 `workflow_dispatch` is enabled, so you can also trigger the pipeline manually
 from the Actions tab.
 
+## Ingestion
+
+Deck plans are encoded as YAML under `data/ships/<slug>/` — one `ship.yaml`
+plus one `deck-<n>.yaml` per passenger deck. The contract Claude follows when
+encoding from a screenshot is `docs/data-schema.md`.
+
+`ingestion/normalize.ts` is the thin layer between the YAML and the database:
+it validates each file, maps to row-shaped output for `ships`, `decks`,
+`cabins`, `spaces`, and derives `cabin_space_proximity` rows by computing
+point-to-bbox euclidean distance from each cabin to spaces on nearby decks
+(`|vertical_decks| ≤ 3`, `horizontal_distance ≤ 30`). Run it standalone to
+inspect the output for a single ship:
+
+```bash
+bun run ingestion/normalize.ts data/ships/<slug>
+```
+
+The seed script (`ingestion/seed.ts`) consumes this output and writes to
+Supabase. It's a separate phase — see issue #8.
+
 ## Status
 
-Scaffolding only. Tool handlers return stub responses. Ingestion pipeline and
-noise scoring algorithm are separate phases.
+Scaffolding plus a normalization layer. Tool handlers still return stub
+responses. The seed script and the noise scoring algorithm are the next
+phases.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.14",
         "postgres": "^3.4.9",
+        "yaml": "^2.8.4",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -402,6 +403,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "yaml": ["yaml@2.8.4", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 

--- a/ingestion/normalize.test.ts
+++ b/ingestion/normalize.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import {
+  computeProximities,
+  normalizeShip,
+  pointToBboxDistance,
+  PROXIMITY_HORIZONTAL_DISTANCE_MAX,
+  PROXIMITY_VERTICAL_DECKS_MAX,
+  type CabinRow,
+  type SpaceRow,
+} from "./normalize";
+
+describe("pointToBboxDistance", () => {
+  test("returns 0 when point is inside the bbox", () => {
+    expect(pointToBboxDistance(50, 50, 40, 60, 40, 60)).toBe(0);
+  });
+
+  test("returns axis distance when offset along one axis only", () => {
+    expect(pointToBboxDistance(70, 50, 40, 60, 40, 60)).toBe(10);
+    expect(pointToBboxDistance(30, 50, 40, 60, 40, 60)).toBe(10);
+    expect(pointToBboxDistance(50, 75, 40, 60, 40, 60)).toBe(15);
+  });
+
+  test("returns euclidean distance when offset along both axes (corner case)", () => {
+    expect(pointToBboxDistance(63, 64, 40, 60, 40, 60)).toBeCloseTo(5, 6);
+  });
+
+  test("returns 0 on bbox boundary", () => {
+    expect(pointToBboxDistance(40, 50, 40, 60, 40, 60)).toBe(0);
+    expect(pointToBboxDistance(60, 60, 40, 60, 40, 60)).toBe(0);
+  });
+});
+
+describe("computeProximities", () => {
+  const cabin = (
+    deckNumber: number,
+    number: string,
+    foreAft: number,
+    portStarboard: number,
+  ): CabinRow => ({
+    deckNumber,
+    number,
+    category: "balcony",
+    foreAft,
+    portStarboard,
+    accessible: false,
+    connecting: false,
+    obstructedView: false,
+    notes: null,
+  });
+
+  const space = (
+    deckNumber: number,
+    localIndex: number,
+    bbox: [number, number, number, number],
+  ): SpaceRow => ({
+    deckNumber,
+    localIndex,
+    type: "nightclub",
+    name: "test",
+    foreAftMin: bbox[0],
+    foreAftMax: bbox[1],
+    portStarboardMin: bbox[2],
+    portStarboardMax: bbox[3],
+    enclosed: true,
+    noiseLevel: 80,
+    openToAbove: false,
+    openToBelow: false,
+    notes: null,
+  });
+
+  test("emits one row per cabin/space pair within both thresholds", () => {
+    const cabins = [cabin(8, "8420", 50, 50)];
+    const spaces = [space(10, 0, [40, 60, 40, 60])];
+    const rows = computeProximities(cabins, spaces);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      cabinDeckNumber: 8,
+      cabinNumber: "8420",
+      spaceDeckNumber: 10,
+      spaceLocalIndex: 0,
+      verticalDecks: 2,
+      horizontalDistance: 0,
+    });
+  });
+
+  test("verticalDecks is signed: +1 means space is one deck above cabin", () => {
+    const cabins = [cabin(5, "5000", 50, 50)];
+    const spaces = [
+      space(6, 0, [45, 55, 45, 55]),
+      space(4, 0, [45, 55, 45, 55]),
+    ];
+    const rows = computeProximities(cabins, spaces);
+    const above = rows.find((r) => r.spaceDeckNumber === 6);
+    const below = rows.find((r) => r.spaceDeckNumber === 4);
+    expect(above?.verticalDecks).toBe(1);
+    expect(below?.verticalDecks).toBe(-1);
+  });
+
+  test("excludes pairs beyond the vertical-decks threshold", () => {
+    const cabins = [cabin(5, "5000", 50, 50)];
+    const justOver = PROXIMITY_VERTICAL_DECKS_MAX + 1;
+    const spaces = [
+      space(5 + justOver, 0, [45, 55, 45, 55]),
+      space(5 - justOver, 0, [45, 55, 45, 55]),
+    ];
+    expect(computeProximities(cabins, spaces)).toHaveLength(0);
+  });
+
+  test("excludes pairs beyond the horizontal-distance threshold", () => {
+    const cabins = [cabin(5, "5000", 0, 0)];
+    // bbox is at the far corner — its closest point is at (50, 50),
+    // distance sqrt(50^2 + 50^2) ≈ 70.7, well past the 30 threshold.
+    const spaces = [space(5, 0, [50, 60, 50, 60])];
+    expect(computeProximities(cabins, spaces)).toHaveLength(0);
+  });
+
+  test("includes pairs exactly at the horizontal-distance threshold", () => {
+    const cabins = [cabin(5, "5000", 0, 50)];
+    const spaces = [
+      space(5, 0, [PROXIMITY_HORIZONTAL_DISTANCE_MAX, 60, 40, 60]),
+    ];
+    const rows = computeProximities(cabins, spaces);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.horizontalDistance).toBeCloseTo(
+      PROXIMITY_HORIZONTAL_DISTANCE_MAX,
+      6,
+    );
+  });
+});
+
+describe("normalizeShip", () => {
+  test("parses ship.yaml + deck files and produces normalized rows", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "normalize-"));
+    await writeFile(
+      path.join(dir, "ship.yaml"),
+      `slug: test-ship
+name: Test Ship
+cruise_line: Test Line
+deck_count: 12
+`,
+    );
+    await writeFile(
+      path.join(dir, "deck-8.yaml"),
+      `deck: 8
+name: Caribbean
+passenger: true
+cabins:
+  - number: "8420"
+    category: balcony
+    fore_aft: 50
+    port_starboard: 50
+spaces:
+  - type: corridor
+    name: ""
+    fore_aft: [40, 60]
+    port_starboard: [40, 60]
+    enclosed: true
+    noise_level: 25
+`,
+    );
+    await writeFile(
+      path.join(dir, "deck-10.yaml"),
+      `deck: 10
+passenger: true
+spaces:
+  - type: nightclub
+    name: The Tube
+    fore_aft: [45, 55]
+    port_starboard: [45, 55]
+    enclosed: true
+    noise_level: 85
+`,
+    );
+
+    const result = await normalizeShip(dir);
+
+    expect(result.ship.slug).toBe("test-ship");
+    expect(result.ship.deckCount).toBe(12);
+    expect(result.ship.class).toBeNull();
+    expect(result.decks.map((d) => d.deckNumber)).toEqual([8, 10]);
+    expect(result.cabins).toHaveLength(1);
+    expect(result.spaces).toHaveLength(2);
+
+    const proximity = result.proximity.find(
+      (p) => p.cabinNumber === "8420" && p.spaceDeckNumber === 10,
+    );
+    expect(proximity).toBeDefined();
+    expect(proximity?.verticalDecks).toBe(2);
+    expect(proximity?.horizontalDistance).toBe(0);
+  });
+
+  test("rejects deck file whose `deck:` field disagrees with filename", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "normalize-"));
+    await writeFile(
+      path.join(dir, "ship.yaml"),
+      `slug: test
+name: Test
+cruise_line: Test
+deck_count: 12
+`,
+    );
+    await writeFile(
+      path.join(dir, "deck-8.yaml"),
+      `deck: 9
+passenger: true
+`,
+    );
+    await expect(normalizeShip(dir)).rejects.toThrow(
+      /filename deck number .* does not match/,
+    );
+  });
+
+  test("rejects ship dir missing ship.yaml", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "normalize-"));
+    await mkdir(path.join(dir, "empty"), { recursive: true });
+    await expect(normalizeShip(path.join(dir, "empty"))).rejects.toThrow();
+  });
+});

--- a/ingestion/normalize.ts
+++ b/ingestion/normalize.ts
@@ -1,0 +1,358 @@
+// Normalize per-ship YAML (matching docs/data-schema.md) into row-shaped
+// output the seed script writes to the database. Ships, decks, cabins, and
+// spaces map ~1:1 from YAML; cabin_space_proximity rows are derived here by
+// scanning each cabin against spaces on nearby decks.
+//
+// FK references between rows use natural keys (deck number, cabin number,
+// space localIndex within its deck) rather than UUIDs — those are generated
+// by Postgres at insert time. The seed script resolves natural keys to UUIDs
+// after each table is inserted.
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as yaml from "yaml";
+import { z } from "zod";
+
+const cabinCategorySchema = z.enum([
+  "interior",
+  "oceanview",
+  "balcony",
+  "suite",
+]);
+
+const spaceTypeSchema = z.enum([
+  "nightclub",
+  "live_music_venue",
+  "theater",
+  "showroom",
+  "arcade",
+  "casino",
+  "bar",
+  "lounge",
+  "pool",
+  "splash_zone",
+  "waterslide",
+  "kids_club",
+  "teen_club",
+  "sports_court",
+  "atrium",
+  "main_dining_room",
+  "specialty_dining",
+  "buffet",
+  "cafe",
+  "shops",
+  "photo_studio",
+  "reception",
+  "guest_services",
+  "spa",
+  "gym",
+  "library",
+  "chapel",
+  "conference_room",
+  "lecture_hall",
+  "art_gallery",
+  "observation_lounge",
+  "medical",
+  "adults_only_lounge",
+  "elevator_bank",
+  "stairs",
+  "corridor",
+  "crew_area",
+  "galley",
+  "mechanical",
+  "laundry",
+  "restroom",
+  "storage",
+  "open_deck",
+  "sun_deck",
+  "promenade",
+  "jogging_track",
+  "helipad",
+  "other",
+]);
+
+export type CabinCategory = z.infer<typeof cabinCategorySchema>;
+export type SpaceType = z.infer<typeof spaceTypeSchema>;
+
+const pct = z.number().min(0).max(100);
+
+const bboxTuple = z
+  .tuple([pct, pct])
+  .refine(([min, max]) => min <= max, {
+    message: "bbox tuple must be [min, max] with min <= max",
+  });
+
+const shipYamlSchema = z.object({
+  slug: z.string().min(1),
+  name: z.string().min(1),
+  cruise_line: z.string().min(1),
+  class: z.string().optional(),
+  gross_tonnage: z.number().int().optional(),
+  year_built: z.number().int().optional(),
+  length_m: z.number().optional(),
+  beam_m: z.number().optional(),
+  deck_count: z.number().int().min(1),
+  notes: z.string().optional(),
+});
+
+const cabinYamlSchema = z.object({
+  number: z.string().min(1),
+  category: cabinCategorySchema,
+  fore_aft: pct,
+  port_starboard: pct,
+  accessible: z.boolean().optional().default(false),
+  connecting: z.boolean().optional().default(false),
+  obstructed_view: z.boolean().optional().default(false),
+  notes: z.string().optional(),
+});
+
+const spaceYamlSchema = z.object({
+  type: spaceTypeSchema,
+  name: z.string(),
+  fore_aft: bboxTuple,
+  port_starboard: bboxTuple,
+  enclosed: z.boolean(),
+  noise_level: z.number().int().min(0).max(100),
+  open_to_above: z.boolean().optional().default(false),
+  open_to_below: z.boolean().optional().default(false),
+  notes: z.string().optional(),
+});
+
+const deckYamlSchema = z.object({
+  deck: z.number().int(),
+  name: z.string().optional(),
+  passenger: z.boolean(),
+  notes: z.string().optional(),
+  cabins: z.array(cabinYamlSchema).optional().default([]),
+  spaces: z.array(spaceYamlSchema).optional().default([]),
+});
+
+export type ShipRow = {
+  slug: string;
+  name: string;
+  cruiseLine: string;
+  class: string | null;
+  grossTonnage: number | null;
+  yearBuilt: number | null;
+  lengthM: number | null;
+  beamM: number | null;
+  deckCount: number;
+  notes: string | null;
+};
+
+export type DeckRow = {
+  deckNumber: number;
+  name: string | null;
+  passenger: boolean;
+};
+
+export type CabinRow = {
+  deckNumber: number;
+  number: string;
+  category: CabinCategory;
+  foreAft: number;
+  portStarboard: number;
+  accessible: boolean;
+  connecting: boolean;
+  obstructedView: boolean;
+  notes: string | null;
+};
+
+export type SpaceRow = {
+  deckNumber: number;
+  localIndex: number;
+  type: SpaceType;
+  name: string;
+  foreAftMin: number;
+  foreAftMax: number;
+  portStarboardMin: number;
+  portStarboardMax: number;
+  enclosed: boolean;
+  noiseLevel: number;
+  openToAbove: boolean;
+  openToBelow: boolean;
+  notes: string | null;
+};
+
+export type ProximityRow = {
+  cabinDeckNumber: number;
+  cabinNumber: string;
+  spaceDeckNumber: number;
+  spaceLocalIndex: number;
+  verticalDecks: number;
+  horizontalDistance: number;
+};
+
+export type NormalizedShipData = {
+  ship: ShipRow;
+  decks: DeckRow[];
+  cabins: CabinRow[];
+  spaces: SpaceRow[];
+  proximity: ProximityRow[];
+};
+
+export const PROXIMITY_VERTICAL_DECKS_MAX = 3;
+export const PROXIMITY_HORIZONTAL_DISTANCE_MAX = 30;
+
+export function pointToBboxDistance(
+  pointForeAft: number,
+  pointPortStarboard: number,
+  foreAftMin: number,
+  foreAftMax: number,
+  portStarboardMin: number,
+  portStarboardMax: number,
+): number {
+  const dx = Math.max(foreAftMin - pointForeAft, 0, pointForeAft - foreAftMax);
+  const dy = Math.max(
+    portStarboardMin - pointPortStarboard,
+    0,
+    pointPortStarboard - portStarboardMax,
+  );
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function computeProximities(
+  cabins: readonly CabinRow[],
+  spaces: readonly SpaceRow[],
+): ProximityRow[] {
+  const out: ProximityRow[] = [];
+  for (const cabin of cabins) {
+    for (const space of spaces) {
+      const verticalDecks = space.deckNumber - cabin.deckNumber;
+      if (Math.abs(verticalDecks) > PROXIMITY_VERTICAL_DECKS_MAX) continue;
+      const horizontalDistance = pointToBboxDistance(
+        cabin.foreAft,
+        cabin.portStarboard,
+        space.foreAftMin,
+        space.foreAftMax,
+        space.portStarboardMin,
+        space.portStarboardMax,
+      );
+      if (horizontalDistance > PROXIMITY_HORIZONTAL_DISTANCE_MAX) continue;
+      out.push({
+        cabinDeckNumber: cabin.deckNumber,
+        cabinNumber: cabin.number,
+        spaceDeckNumber: space.deckNumber,
+        spaceLocalIndex: space.localIndex,
+        verticalDecks,
+        horizontalDistance,
+      });
+    }
+  }
+  return out;
+}
+
+const DECK_FILE_RE = /^deck-(\d+)\.yaml$/;
+
+export async function normalizeShip(
+  shipDir: string,
+): Promise<NormalizedShipData> {
+  const shipText = await fs.readFile(path.join(shipDir, "ship.yaml"), "utf8");
+  const shipYaml = shipYamlSchema.parse(yaml.parse(shipText));
+
+  const ship: ShipRow = {
+    slug: shipYaml.slug,
+    name: shipYaml.name,
+    cruiseLine: shipYaml.cruise_line,
+    class: shipYaml.class ?? null,
+    grossTonnage: shipYaml.gross_tonnage ?? null,
+    yearBuilt: shipYaml.year_built ?? null,
+    lengthM: shipYaml.length_m ?? null,
+    beamM: shipYaml.beam_m ?? null,
+    deckCount: shipYaml.deck_count,
+    notes: shipYaml.notes ?? null,
+  };
+
+  const entries = await fs.readdir(shipDir);
+  const deckFiles = entries
+    .filter((e) => DECK_FILE_RE.test(e))
+    .sort((a, b) => parseDeckFileNumber(a) - parseDeckFileNumber(b));
+
+  const decks: DeckRow[] = [];
+  const cabins: CabinRow[] = [];
+  const spaces: SpaceRow[] = [];
+  const seenDeckNumbers = new Set<number>();
+
+  for (const file of deckFiles) {
+    const text = await fs.readFile(path.join(shipDir, file), "utf8");
+    const parsed = deckYamlSchema.parse(yaml.parse(text));
+
+    const fileDeckNumber = parseDeckFileNumber(file);
+    if (parsed.deck !== fileDeckNumber) {
+      throw new Error(
+        `${file}: filename deck number (${fileDeckNumber}) does not match \`deck:\` field (${parsed.deck})`,
+      );
+    }
+    if (seenDeckNumbers.has(parsed.deck)) {
+      throw new Error(`duplicate deck number ${parsed.deck} across yaml files`);
+    }
+    seenDeckNumbers.add(parsed.deck);
+
+    decks.push({
+      deckNumber: parsed.deck,
+      name: parsed.name ?? null,
+      passenger: parsed.passenger,
+    });
+
+    const cabinNumbersOnDeck = new Set<string>();
+    for (const c of parsed.cabins) {
+      if (cabinNumbersOnDeck.has(c.number)) {
+        throw new Error(
+          `${file}: duplicate cabin number "${c.number}" on deck ${parsed.deck}`,
+        );
+      }
+      cabinNumbersOnDeck.add(c.number);
+      cabins.push({
+        deckNumber: parsed.deck,
+        number: c.number,
+        category: c.category,
+        foreAft: c.fore_aft,
+        portStarboard: c.port_starboard,
+        accessible: c.accessible,
+        connecting: c.connecting,
+        obstructedView: c.obstructed_view,
+        notes: c.notes ?? null,
+      });
+    }
+
+    parsed.spaces.forEach((s, i) => {
+      spaces.push({
+        deckNumber: parsed.deck,
+        localIndex: i,
+        type: s.type,
+        name: s.name,
+        foreAftMin: s.fore_aft[0],
+        foreAftMax: s.fore_aft[1],
+        portStarboardMin: s.port_starboard[0],
+        portStarboardMax: s.port_starboard[1],
+        enclosed: s.enclosed,
+        noiseLevel: s.noise_level,
+        openToAbove: s.open_to_above,
+        openToBelow: s.open_to_below,
+        notes: s.notes ?? null,
+      });
+    });
+  }
+
+  const proximity = computeProximities(cabins, spaces);
+
+  return { ship, decks, cabins, spaces, proximity };
+}
+
+function parseDeckFileNumber(filename: string): number {
+  const m = filename.match(DECK_FILE_RE);
+  if (!m || m[1] === undefined) {
+    throw new Error(`not a deck file: ${filename}`);
+  }
+  return Number.parseInt(m[1], 10);
+}
+
+if (import.meta.main) {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error("usage: bun run ingestion/normalize.ts <ship-dir>");
+    process.exit(1);
+  }
+  const result = await normalizeShip(dir);
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.14",
     "postgres": "^3.4.9",
+    "yaml": "^2.8.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds `ingestion/normalize.ts`: reads `data/ships/<slug>/{ship,deck-N}.yaml`, validates against the contract in `docs/data-schema.md` with zod, and emits row-shaped output for `ships`, `decks`, `cabins`, `spaces` keyed by natural keys (deck number, cabin number, space `localIndex`) so the seed script can resolve them to UUIDs after insert.
- Derives `cabin_space_proximity` rows: for each cabin × space pair within `|vertical_decks| ≤ 3` and point-to-bbox euclidean `horizontal_distance ≤ 30`, emits one row with signed `vertical_decks` (+1 = space one deck above cabin).
- Adds `ingestion/normalize.test.ts` covering bbox math (inside/boundary/corner), threshold filtering, signed vertical decks, and end-to-end YAML parsing.

Closes #7.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test ingestion/normalize.test.ts` (12 pass)
- [ ] Spot-check JSON output by running `bun run ingestion/normalize.ts data/ships/<slug>` once a real ship dir exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)