### PR TITLE
Add seed workflow for ship data on push to main

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1,0 +1,68 @@
+name: Seed
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/ships/**"
+      - "ingestion/seed.ts"
+      - "ingestion/normalize.ts"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/seed.yml"
+  workflow_dispatch:
+    inputs:
+      ship:
+        description: "Ship slug to seed (leave blank to seed every ship under data/ships/)"
+        required: false
+        default: ""
+
+# Share the cf-deploy lock so seeds never overlap with migrations or another seed.
+concurrency:
+  group: cf-deploy
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    name: ingest:seed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Seed ships
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SHIP_INPUT: ${{ inputs.ship || '' }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          if [[ -n "${SHIP_INPUT}" ]]; then
+            target="data/ships/${SHIP_INPUT}"
+            if [[ ! -d "${target}" ]]; then
+              echo "ship dir not found: ${target}" >&2
+              exit 1
+            fi
+            ships=("${target}")
+          else
+            ships=(data/ships/*/)
+          fi
+          if [[ ${#ships[@]} -eq 0 ]]; then
+            echo "no ship directories under data/ships/ — nothing to seed"
+            exit 0
+          fi
+          for dir in "${ships[@]}"; do
+            slug="$(basename "${dir}")"
+            echo "::group::seeding ${slug}"
+            bun run ingest:seed --ship="${slug}"
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Summary
- New `.github/workflows/seed.yml` that runs `bun run ingest:seed` on push to `main` when ship YAML or the ingestion pipeline changes, and on `workflow_dispatch` for manual reseeds.
- Iterates every subdirectory of `data/ships/` (or a single `ship` input). The seeder is idempotent, so blanket-seeding all ships is fine for v1.
- Shares the existing `cf-deploy` concurrency group so seeds queue behind any in-flight migrate/deploy.

Follow-up to #31. Keeps `DATABASE_URL` in GitHub Secrets so it never has to live on a dev machine.

## Test plan
- [ ] Merge and observe the run on the next ship-data push (issue #16, Disney Fantasy)
- [ ] Manually trigger via `workflow_dispatch` to confirm the input path

🤖 Generated with [Claude Code](https://claude.com/claude-code)